### PR TITLE
Add `Game` abstraction

### DIFF
--- a/spec/unit/game_spec.cr
+++ b/spec/unit/game_spec.cr
@@ -183,6 +183,39 @@ describe "Game" do
 
         ((game.board).as BoardWithSpiedMove).spied_move_calls.should eq([{from: valid_move_from_coordinate, to: valid_move_to_coordinate}])
       end
+
+      it "tracks captured pieces when a capturing move is made (white captures black)" do
+        game = Game.new
+        white_queen = Queen.new(PieceColor::White)
+        black_queen = Queen.new(PieceColor::Black)
+
+        game.board.add_piece({'a', 1}, white_queen)
+        game.board.add_piece({'a', 2}, black_queen)
+        game.move({'a', 1}, {'a', 2})
+
+        game.captured_pieces[:black].size.should eq 0
+        game.captured_pieces[:white].size.should eq 1
+        game.captured_pieces[:white][0].should eq black_queen
+      end
+
+      it "tracks captured pieces when a capturing move is made (black captures white)" do
+        game = Game.new
+        white_queen = Queen.new(PieceColor::White)
+        black_queen = Queen.new(PieceColor::Black)
+
+        game.board.add_piece({'a', 1}, white_queen)
+        game.board.add_piece({'a', 2}, black_queen)
+
+        # move white queen, making it black's turn
+        game.move({'a', 1}, {'b', 1})
+
+        # move black queen to capture white queen
+        game.move({'a', 2}, {'b', 1})
+
+        game.captured_pieces[:white].size.should eq 0
+        game.captured_pieces[:black].size.should eq 1
+        game.captured_pieces[:black][0].should eq white_queen
+      end
     end
   end
 end

--- a/spec/unit/game_spec.cr
+++ b/spec/unit/game_spec.cr
@@ -1,0 +1,14 @@
+require "spec"
+require "../../src/game"
+
+describe "Game" do
+  it "can be initialized" do
+    game = Game.new
+    (game.is_a? Game).should be_true
+  end
+
+  it "has a board" do
+    game = Game.new
+    (game.board.is_a? Board).should be_true
+  end
+end

--- a/spec/unit/game_spec.cr
+++ b/spec/unit/game_spec.cr
@@ -35,6 +35,11 @@ describe "Game" do
       game = Game.new
       (game.board.is_a? Board).should be_true
     end
+
+    it "has an empty moves array" do
+      game = Game.new
+      game.moves.should eq [] of GameTrackedMove
+    end
   end
 
   describe "#setup_board" do
@@ -216,6 +221,23 @@ describe "Game" do
         game.captured_pieces[:black].size.should eq 1
         game.captured_pieces[:black][0].should eq white_queen
       end
+    end
+  end
+
+  describe "#moves" do
+    it "returns previously made moves" do
+      game = Game.new
+      game.setup_board
+
+      game.moves.should eq [] of GameTrackedMove
+
+      first_move = {from: {'a', 2}, to: {'a', 3}}
+      game.move(first_move[:from], first_move[:to])
+      game.moves.should eq [first_move]
+
+      second_move = {from: {'a', 7}, to: {'a', 6}}
+      game.move(second_move[:from], second_move[:to])
+      game.moves.should eq [first_move, second_move]
     end
   end
 end

--- a/spec/unit/game_spec.cr
+++ b/spec/unit/game_spec.cr
@@ -11,4 +11,88 @@ describe "Game" do
     game = Game.new
     (game.board.is_a? Board).should be_true
   end
+
+  describe "#setup_board" do
+    describe "it setups the board correctly" do
+      it "has all the white pieces in the correct location" do
+        game = Game.new
+        game.setup_board
+
+        (game.board.piece_at_coordinate({'a', 1}).is_a? Rook).should be_true
+        (game.board.piece_at_coordinate({'b', 1}).is_a? Knight).should be_true
+        (game.board.piece_at_coordinate({'c', 1}).is_a? Bishop).should be_true
+        (game.board.piece_at_coordinate({'d', 1}).is_a? Queen).should be_true
+        (game.board.piece_at_coordinate({'e', 1}).is_a? King).should be_true
+        (game.board.piece_at_coordinate({'f', 1}).is_a? Bishop).should be_true
+        (game.board.piece_at_coordinate({'g', 1}).is_a? Knight).should be_true
+        (game.board.piece_at_coordinate({'h', 1}).is_a? Rook).should be_true
+
+        (game.board.piece_at_coordinate({'a', 2}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'b', 2}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'c', 2}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'d', 2}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'e', 2}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'f', 2}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'g', 2}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'h', 2}).is_a? Pawn).should be_true
+
+        ((game.board.piece_at_coordinate({'a', 1}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'b', 1}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'c', 1}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'d', 1}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'e', 1}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'f', 1}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'g', 1}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'h', 1}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'a', 2}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'b', 2}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'c', 2}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'d', 2}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'e', 2}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'f', 2}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'g', 2}).as Piece).color).should eq PieceColor::White
+        ((game.board.piece_at_coordinate({'h', 2}).as Piece).color).should eq PieceColor::White
+      end
+
+      it "has all the black pieces in the correct location" do
+        game = Game.new
+        game.setup_board
+
+        (game.board.piece_at_coordinate({'a', 8}).is_a? Rook).should be_true
+        (game.board.piece_at_coordinate({'b', 8}).is_a? Knight).should be_true
+        (game.board.piece_at_coordinate({'c', 8}).is_a? Bishop).should be_true
+        (game.board.piece_at_coordinate({'d', 8}).is_a? Queen).should be_true
+        (game.board.piece_at_coordinate({'e', 8}).is_a? King).should be_true
+        (game.board.piece_at_coordinate({'f', 8}).is_a? Bishop).should be_true
+        (game.board.piece_at_coordinate({'g', 8}).is_a? Knight).should be_true
+        (game.board.piece_at_coordinate({'h', 8}).is_a? Rook).should be_true
+
+        (game.board.piece_at_coordinate({'a', 7}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'b', 7}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'c', 7}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'d', 7}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'e', 7}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'f', 7}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'g', 7}).is_a? Pawn).should be_true
+        (game.board.piece_at_coordinate({'h', 7}).is_a? Pawn).should be_true
+
+        ((game.board.piece_at_coordinate({'a', 7}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'b', 7}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'c', 7}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'d', 7}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'e', 7}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'f', 7}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'g', 7}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'h', 7}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'a', 8}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'b', 8}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'c', 8}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'d', 8}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'e', 8}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'f', 8}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'g', 8}).as Piece).color).should eq PieceColor::Black
+        ((game.board.piece_at_coordinate({'h', 8}).as Piece).color).should eq PieceColor::Black
+      end
+    end
+  end
 end

--- a/spec/unit/game_spec.cr
+++ b/spec/unit/game_spec.cr
@@ -7,6 +7,11 @@ describe "Game" do
     (game.is_a? Game).should be_true
   end
 
+  it "initializes with the first turn for the white pieces" do
+    game = Game.new
+    game.turn.should eq PieceColor::White
+  end
+
   it "has a board" do
     game = Game.new
     (game.board.is_a? Board).should be_true

--- a/src/game.cr
+++ b/src/game.cr
@@ -32,7 +32,7 @@ class Game
     end
 
     captured_piece = board.move(from, to)
-    if (captured_piece.is_a? Piece)
+    if captured_piece.is_a? Piece
       captured_pieces[@turn.to_sym].push(captured_piece)
     end
 

--- a/src/game.cr
+++ b/src/game.cr
@@ -1,0 +1,7 @@
+require "./board"
+
+class Game
+  def initialize
+    @board = Board.new
+  end
+end

--- a/src/game.cr
+++ b/src/game.cr
@@ -1,17 +1,37 @@
 require "./board"
 
+alias GameTrackedMove = NamedTuple(from: BoardCoordinate, to: BoardCoordinate)
+
 class Game
-  getter board
+  getter board : Board
   getter turn : PieceColor
 
-  def initialize
-    @board = Board.new
+  @moves : Array(GameTrackedMove) = [] of GameTrackedMove
+
+  def initialize(board : Board = Board.new)
+    @board = board
     @turn = PieceColor::White
   end
 
   def setup_board
     add_starting_white_pieces
     add_starting_black_pieces
+  end
+
+  def move(from : BoardCoordinate, to : BoardCoordinate)
+    piece_to_move = board.piece_at_coordinate from
+
+    if piece_to_move.nil?
+      raise "Expected the `from` argument to be the coordinate of a piece"
+    end
+
+    if piece_to_move.color != @turn
+      raise "Cannot move piece #{piece_to_move} at #{from} because the turn is set to color #{@turn} but that piece has color #{piece_to_move.color}"
+    end
+
+    captured_piece = board.move(from, to)
+    @moves.push({from: from, to: to})
+    @turn = @turn.inverse
   end
 
   private def add_starting_white_pieces

--- a/src/game.cr
+++ b/src/game.cr
@@ -5,6 +5,7 @@ alias GameTrackedMove = NamedTuple(from: BoardCoordinate, to: BoardCoordinate)
 class Game
   getter board : Board
   getter turn : PieceColor
+  getter captured_pieces = {white: [] of Piece, black: [] of Piece}
 
   @moves : Array(GameTrackedMove) = [] of GameTrackedMove
 
@@ -30,6 +31,10 @@ class Game
     end
 
     captured_piece = board.move(from, to)
+    if (captured_piece.is_a? Piece)
+      captured_pieces[@turn.to_sym].push(captured_piece)
+    end
+
     @moves.push({from: from, to: to})
     @turn = @turn.inverse
   end

--- a/src/game.cr
+++ b/src/game.cr
@@ -6,6 +6,7 @@ class Game
   getter board : Board
   getter turn : PieceColor
   getter captured_pieces = {white: [] of Piece, black: [] of Piece}
+  getter moves : Array(GameTrackedMove)
 
   @moves : Array(GameTrackedMove) = [] of GameTrackedMove
 

--- a/src/game.cr
+++ b/src/game.cr
@@ -2,9 +2,11 @@ require "./board"
 
 class Game
   getter board
+  getter turn : PieceColor
 
   def initialize
     @board = Board.new
+    @turn = PieceColor::White
   end
 
   def setup_board

--- a/src/game.cr
+++ b/src/game.cr
@@ -1,7 +1,54 @@
 require "./board"
 
 class Game
+  getter board
+
   def initialize
     @board = Board.new
+  end
+
+  def setup_board
+    add_starting_white_pieces
+    add_starting_black_pieces
+  end
+
+  private def add_starting_white_pieces
+    board.add_piece({'a', 1}, Rook.new(PieceColor::White))
+    board.add_piece({'b', 1}, Knight.new(PieceColor::White))
+    board.add_piece({'c', 1}, Bishop.new(PieceColor::White))
+    board.add_piece({'d', 1}, Queen.new(PieceColor::White))
+    board.add_piece({'e', 1}, King.new(PieceColor::White))
+    board.add_piece({'f', 1}, Bishop.new(PieceColor::White))
+    board.add_piece({'g', 1}, Knight.new(PieceColor::White))
+    board.add_piece({'h', 1}, Rook.new(PieceColor::White))
+
+    board.add_piece({'a', 2}, Pawn.new(PieceColor::White))
+    board.add_piece({'b', 2}, Pawn.new(PieceColor::White))
+    board.add_piece({'c', 2}, Pawn.new(PieceColor::White))
+    board.add_piece({'d', 2}, Pawn.new(PieceColor::White))
+    board.add_piece({'e', 2}, Pawn.new(PieceColor::White))
+    board.add_piece({'f', 2}, Pawn.new(PieceColor::White))
+    board.add_piece({'g', 2}, Pawn.new(PieceColor::White))
+    board.add_piece({'h', 2}, Pawn.new(PieceColor::White))
+  end
+
+  private def add_starting_black_pieces
+    board.add_piece({'a', 7}, Pawn.new(PieceColor::Black))
+    board.add_piece({'b', 7}, Pawn.new(PieceColor::Black))
+    board.add_piece({'c', 7}, Pawn.new(PieceColor::Black))
+    board.add_piece({'d', 7}, Pawn.new(PieceColor::Black))
+    board.add_piece({'e', 7}, Pawn.new(PieceColor::Black))
+    board.add_piece({'f', 7}, Pawn.new(PieceColor::Black))
+    board.add_piece({'g', 7}, Pawn.new(PieceColor::Black))
+    board.add_piece({'h', 7}, Pawn.new(PieceColor::Black))
+
+    board.add_piece({'a', 8}, Rook.new(PieceColor::Black))
+    board.add_piece({'b', 8}, Knight.new(PieceColor::Black))
+    board.add_piece({'c', 8}, Bishop.new(PieceColor::Black))
+    board.add_piece({'d', 8}, Queen.new(PieceColor::Black))
+    board.add_piece({'e', 8}, King.new(PieceColor::Black))
+    board.add_piece({'f', 8}, Bishop.new(PieceColor::Black))
+    board.add_piece({'g', 8}, Knight.new(PieceColor::Black))
+    board.add_piece({'h', 8}, Rook.new(PieceColor::Black))
   end
 end

--- a/src/piece.cr
+++ b/src/piece.cr
@@ -7,6 +7,10 @@ enum PieceColor
   def inverse
     self == PieceColor::White ? PieceColor::Black : PieceColor::White
   end
+
+  def to_sym
+    self == PieceColor::White ? :white : :black
+  end
 end
 
 MAX_SQUARE_MOVES = 7


### PR DESCRIPTION
The game abstraction will provide an extra layer on top of the board including:
* Initializing the setup of the board with the default pieces
* Tracking history of moves
* Tracking which `PieceColor` the current `@turn` is (only piece moves for the current `@turn` are allowed)
* (future PR) Enforce valid moves eg: castling can only be done under specific game conditions). This will be an enforcement that can only be done at this level. Moves should validated as locally as possible starting with the `Piece` describing its valid moves and capturing moves, then the `Board` with an understanding of board bounds and relationships between pieces like pieces being blocked, and lastly at the `Game` level (eg: castling can't occur if the rook or king have already been moved, amongst other conditions)