### PR TITLE
Add ci github action for crystal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+# This CI job installs Crystal and shard dependencies, then executes `crystal spec` to run the test suite
+# More configuration options are available at https://crystal-lang.github.io/install-crystal/configurator.html
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download source
+        uses: actions/checkout@v4
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Install shards
+        run: shards install
+      - name: Run tests
+        run: crystal spec --order=random
+      - name: Build
+        run: shards build
+      - name: Check formatting
+        run: crystal tool format; git diff --exit-code

--- a/shard.yml
+++ b/shard.yml
@@ -12,3 +12,7 @@ description: |
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+
+targets:
+  cchess:
+    main: src/main.cr


### PR DESCRIPTION
Add CI checks to build and test the project. Github action yaml generated from [install-crystal configurator](https://crystal-lang.github.io/install-crystal/configurator.html).