### PR TITLE
Add `Board#clone`

### DIFF
--- a/spec/unit/board_spec.cr
+++ b/spec/unit/board_spec.cr
@@ -285,4 +285,39 @@ describe "Board" do
       end
     end
   end
+
+  describe "#clone" do
+    board : Board = Board.new
+    pawn = Pawn.new(PieceColor::Black)
+    pawn_at_coordinate = {'a', 8}
+
+    before_each do
+      board = Board.new
+      pawn = Pawn.new(PieceColor::Black)
+      board.add_piece(pawn_at_coordinate, pawn)
+    end
+
+    it "creates a Board with a copy of @structure" do
+      board.piece_at_coordinate(pawn_at_coordinate).should eq pawn
+
+      board_clone : Board = board.clone
+
+      # `board_clone` instance is not identical to the original `board` instance
+      board_clone.should_not be board
+
+      # `board_clone` structure is not strictly identical except in structure
+      board_clone.structure.should_not be board.structure
+      board_clone.structure.should eq board.structure
+
+      # `board_clone` structure row/rank is not strictly identical except in structure
+      board_clone.structure[0].should_not be board.structure[0]
+      board_clone.structure[0].should eq board.structure[0]
+    end
+
+    it "creates a new board structure but references the same original pieces instances" do
+      board.piece_at_coordinate(pawn_at_coordinate).should eq pawn
+      board_clone : Board = board.clone
+      board_clone.piece_at_coordinate(pawn_at_coordinate).should eq pawn
+    end
+  end
 end

--- a/spec/unit/board_spec.cr
+++ b/spec/unit/board_spec.cr
@@ -50,11 +50,32 @@ class ForwardMovingPieceWithCaptureMove < Piece
 end
 
 describe "Board" do
-  it "initializes with an empty array" do
-    board = Board.new
+  describe "#initialize" do
+    it "initializes with an empty array when a BoardStructure is not passed in" do
+      board = Board.new
 
-    # 8 x 8 array of `nil`
-    board.structure.should eq empty_board
+      # 8 x 8 array of `nil`
+      board.structure.should eq empty_board
+    end
+
+    it "raises if a BoardStructure passed in is not valid" do
+      board_structure : BoardStructure = [[] of Piece | Nil]
+      expect_raises(Exception, "Array structure for board is invalid, [[]]") do
+        board = Board.new(board_structure)
+      end
+    end
+
+    it "accepts a valid BoardStructure" do
+      board = Board.new
+      pawn = Pawn.new(PieceColor::Black)
+      board.add_piece({'a', 8}, pawn)
+      existing_board_structure = board.structure
+      existing_board_structure[0][0].should eq pawn
+
+      board_with_existing_structure = Board.new(existing_board_structure)
+      board_with_existing_structure.structure.should eq existing_board_structure
+      board_with_existing_structure.structure[0][0].should eq pawn
+    end
   end
 
   describe "#add_piece" do

--- a/src/board.cr
+++ b/src/board.cr
@@ -22,11 +22,12 @@ class Board
   getter structure : BoardStructure
 
   def initialize(structure : BoardStructure? = nil)
-    if (structure.nil?)
-      structure = Array.new(DEFAULT_BOARD_RANK_COUNT) { Array(Piece | Nil).new(DEFAULT_BOARD_FILE_COUNT, nil) }
+    if structure.nil?
+      @structure = Array.new(DEFAULT_BOARD_RANK_COUNT) { Array(Piece | Nil).new(DEFAULT_BOARD_FILE_COUNT, nil) }
+      return
     end
 
-    raise "Array structure for board is invalid, #{structure}" if is_valid_board_structure?(structure) == false
+    raise "Array structure for board is invalid, #{structure}" if valid_board_structure?(structure) == false
     @structure = structure
   end
 
@@ -189,7 +190,7 @@ class Board
     Board.new(cloned_structure)
   end
 
-  private def is_valid_board_structure?(structure : BoardStructure) : Bool
+  private def valid_board_structure?(structure : BoardStructure) : Bool
     return false if structure.size != DEFAULT_BOARD_RANK_COUNT
 
     structure.each do |file|
@@ -201,6 +202,6 @@ class Board
       end
     end
 
-    return true
+    true
   end
 end

--- a/src/board.cr
+++ b/src/board.cr
@@ -182,7 +182,11 @@ class Board
   end
 
   def clone : Board
-    Board.new(@structure)
+    cloned_structure = @structure.map do |rank|
+      rank.dup
+    end
+
+    Board.new(cloned_structure)
   end
 
   private def is_valid_board_structure?(structure : BoardStructure) : Bool

--- a/src/board.cr
+++ b/src/board.cr
@@ -15,14 +15,19 @@ PieceCharacterSymbol = {
   King:   "♚",
 }
 
-DEFAULT_RANK_COUNT = 8
-DEFAULT_FILE_COUNT = 8
+DEFAULT_BOARD_RANK_COUNT = 8
+DEFAULT_BOARD_FILE_COUNT = 8
 
 class Board
-  getter structure
+  getter structure : BoardStructure
 
-  def initialize
-    @structure = Array(Array(Piece | Nil)).new(DEFAULT_RANK_COUNT) { Array(Piece | Nil).new(DEFAULT_FILE_COUNT, nil) }
+  def initialize(structure : BoardStructure? = nil)
+    if (structure.nil?)
+      structure = Array.new(DEFAULT_BOARD_RANK_COUNT) { Array(Piece | Nil).new(DEFAULT_BOARD_FILE_COUNT, nil) }
+    end
+
+    raise "Array structure for board is invalid, #{structure}" if is_valid_board_structure?(structure) == false
+    @structure = structure
   end
 
   def add_piece(coordinate : BoardCoordinate, piece : Piece)
@@ -174,5 +179,24 @@ class Board
 
     # output edge of board file markers
     draw_output += "   a  b  c  d  e  f  g  h"
+  end
+
+  def clone : Board
+    Board.new(@structure)
+  end
+
+  private def is_valid_board_structure?(structure : BoardStructure) : Bool
+    return false if structure.size != DEFAULT_BOARD_RANK_COUNT
+
+    structure.each do |file|
+      return false if structure.size != DEFAULT_BOARD_FILE_COUNT
+
+      file.each do |piece_or_nil|
+        # Realistically, this is expected to be caught by the compiler
+        return false if piece_or_nil != nil && piece_or_nil.is_a? Piece != true
+      end
+    end
+
+    return true
   end
 end

--- a/src/spatial.cr
+++ b/src/spatial.cr
@@ -4,6 +4,8 @@ alias BoardCoordinate = {Char, Int32}
 # Represents a position within the array matrix representation how pieces are stored
 alias ArrayMatrixCoordinate = {Int32, Int32}
 
+alias BoardStructure = Array(Array(Piece | Nil))
+
 # Describes the movement of Knights
 # LONG - The jump starts with two squares and then one over
 # SHORT - The jump starts with one forward and then two over


### PR DESCRIPTION
Adding `Board#clone` enables creating new `Board` instances with their own fresh underlying array structure _but_ sharing the same `Piece`s. This allows alternate scenarios to be explored without affecting the original board.

This might be one useful approach in preventing moves that result in check or checkmate (see #5). A board with a possible move could clone the board, make the move, and check if the move is in check or checkmate, while leaving the original board untouched.

Another use case of easily creating board copies is that it could also be used for the history of a game. In an immutable fashion, every `#move` results in a cloned `Board` being stashed in `history`.